### PR TITLE
Add link to fpdf2 + .id on headings in maintainer-guidelines.md

### DIFF
--- a/content/pages/maintainer-guidelines.md
+++ b/content/pages/maintainer-guidelines.md
@@ -95,3 +95,43 @@ Depending on the projects, the release process can be automated inside GitHub Ac
 <!-- TODO: use a dedicated Pypi user like Jazzband does? cf. https://jazzband.co/about/releases -->
 
 <!-- TODO: add a section on Security & reporting vulnerabilities ? cf. https://jazzband.co/about/security -->
+
+<script>
+const ANCHOR_ID_CHAR_RANGE_TO_IGNORE = '[\x00-\x2F\x3A-\x40\x5B-\x60\x7B-\uFFFF]+';
+function slugify(s) {
+  var s = String(s)
+  s = s.trim()
+  s = s.toLowerCase()
+  s = s.replace(new RegExp('^'+ANCHOR_ID_CHAR_RANGE_TO_IGNORE, 'g'), '')
+  s = s.replace(new RegExp(ANCHOR_ID_CHAR_RANGE_TO_IGNORE, 'g'), '-')
+  return encodeURIComponent(s);
+}
+document.querySelectorAll('h2').forEach(function (title) {
+  // Add an HTML "id" based on the heading title slugified:
+  title.id = slugify(title.textContent);
+  // Add a clickable link on hover:
+  var a = document.createElement('a');
+  a.href = document.location + '#' + title.id;
+  a['aria-hidden'] = true;
+  a.style.float = 'left';
+  a.style['padding-right'] = '4px';
+  a.style['margin-left'] = '-20px';
+  a.style['line-height'] = 1;
+  title.appendChild(a);
+  var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('aria-hidden', true);
+  svg.setAttribute('height', 16);
+  svg.setAttribute('width', 16);
+  svg.setAttribute('viewBox', '0 0 16 16');
+  svg.style.color = '#1b1f23';
+  svg.style['vertical-align'] = 'middle';
+  svg.style.visibility = 'hidden';
+  a.appendChild(svg);
+  var path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttributeNS(null, 'fill-rule', 'evenodd');
+  path.setAttributeNS(null, 'd', 'M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z');
+  svg.appendChild(path);
+  title.onmouseover = function () { this.getElementsByTagName('svg')[0].style.visibility = 'visible'; };
+  title.onmouseout = function () { this.getElementsByTagName('svg')[0].style.visibility = 'hidden'; };
+});
+</script>

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -23,6 +23,7 @@ LINKS = (
     # Order the following by Github stars:
     # Either link to GitHub or to PyPI
     ("pypdf and PyPDF2", "https://github.com/py-pdf/pypdf"),
+    ("fpdf2", "https://github.com/py-pdf/fpdf2"),
     ("PyPDF-Builder", "https://github.com/py-pdf/PyPDF-Builder"),
     ("pdfly", "https://github.com/py-pdf/pdfly"),
 )


### PR DESCRIPTION
I used a small JS `<script>` that I have been using for a while in order to create "linkable" headings on this page,
in order for the table of content to work: https://py-pdf.github.io/pages/maintainer-guidelines.html